### PR TITLE
fix: Fix setLogger return type for psr/log 3.0 compatibility

### DIFF
--- a/src/FlatpakAdapter.php
+++ b/src/FlatpakAdapter.php
@@ -58,10 +58,8 @@ class FlatpakAdapter implements Adapter, LoggerAwareInterface
 
     /**
      * Sets a logger instance on the object.
-     *
-     * @return void
      */
-    public function setLogger(LoggerInterface $logger)
+    public function setLogger(LoggerInterface $logger): void
     {
         $this->logger = $logger;
     }


### PR DESCRIPTION
Avoids:
> Declaration of ChristophWurst\KItinerary\Flatpak\FlatpakAdapter::setLogger(Psr\Log\LoggerInterface $logger) must be compatible with Psr\Log\LoggerAwareInterface::setLogger(Psr\Log\LoggerInterface $logger): void at /var/www/html/custom_apps/workflow_kitinerary/vendor/christophwurst/kitinerary-flatpak/src/FlatpakAdapter.php#64

When using psr/log 3.0 (as in Nextcloud 31)